### PR TITLE
token endpoint should use urlencoded request body per rfc6749

### DIFF
--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -70,12 +70,10 @@ describe('auth middleware. _type == password', () => {
       // should only be called 1x b/c the first call sets the access token and it is not expired.
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const req = mockFetch.mock.calls[0][0];
+
       expect(req.url).toEqual('http://base.url/token');
-      expect(await req.json()).toEqual({
-        grant_type: 'password',
-        username: 'fsri',
-        password: 'AddressingFireProblems',
-      });
+      expect(req.headers.get('content-type')).toEqual('application/x-www-form-urlencoded');
+      expect(await req.text()).toEqual(`grant_type=password&username=fsri&password=AddressingFireProblems`);
     }
   });
 
@@ -137,19 +135,14 @@ describe('auth middleware. _type == password', () => {
 
       const req0 = mockFetch.mock.calls[0][0];
       expect(req0.url).toEqual('http://base.url/token');
-      expect(await req0.json()).toEqual({
-        grant_type: 'password',
-        username: 'fsri',
-        password: 'AddressingFireProblems',
-      });
+      expect(req0.headers.get('content-type')).toEqual('application/x-www-form-urlencoded');
+      expect(await req0.text()).toEqual(`grant_type=password&username=fsri&password=AddressingFireProblems`);
 
+      // next call to refresh token since it is expired.
       const req1 = mockFetch.mock.calls[1][0];
       expect(req1.url).toEqual('http://base.url/token');
-      expect(await req1.json()).toEqual({
-        grant_type: 'password',
-        username: 'fsri',
-        password: 'AddressingFireProblems',
-      });
+      expect(req1.headers.get('content-type')).toEqual('application/x-www-form-urlencoded');
+      expect(await req1.text()).toEqual(`grant_type=password&username=fsri&password=AddressingFireProblems`);
     }
   });
 });
@@ -203,7 +196,8 @@ describe('auth middleware. _type == client_credentials', () => {
       const req = mockFetch.mock.calls[0][0];
       expect(req.url).toEqual('http://base.url/token');
       expect(req.headers.get('authorization')).toEqual('Basic MTIzOnNoaGg=');
-      expect(await req.json()).toEqual({ grant_type: 'client_credentials' });
+      expect(req.headers.get('content-type')).toEqual('application/x-www-form-urlencoded');
+      expect(await req.text()).toEqual(`grant_type=client_credentials`);
     }
   });
 
@@ -267,15 +261,14 @@ describe('auth middleware. _type == client_credentials', () => {
 
       const req0 = mockFetch.mock.calls[0][0];
       expect(req0.headers.get('authorization')).toEqual('Basic MTIzOnNoaGg=');
-      expect(await req0.json()).toEqual({ grant_type: 'client_credentials' });
+      expect(req0.headers.get('content-type')).toEqual('application/x-www-form-urlencoded');
+      expect(await req0.text()).toEqual('grant_type=client_credentials');
 
       // next call to refresh token since it is expired.
       const req1 = mockFetch.mock.calls[1][0];
       expect(req1.url).toEqual('http://base.url/token');
-      expect(await req1.json()).toEqual({
-        grant_type: 'refresh_token',
-        refresh_token: 'refresh_token_one',
-      });
+      expect(req1.headers.get('content-type')).toEqual('application/x-www-form-urlencoded');
+      expect(await req1.text()).toEqual('grant_type=refresh_token&refresh_token=refresh_token_one');
     }
   });
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -57,7 +57,13 @@ export const authMiddleware = (config: NerisApiConfig): Middleware => {
           fetch: config.fetch,
         });
 
-        const tokenRes = await client.POST('/token', { body });
+        const tokenRes = await client.POST('/token', {
+          body,
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+          bodySerializer(data) {
+            return new URLSearchParams(data as any).toString();
+          },
+        });
 
         if (tokenRes.error) {
           throw new Error(`authentication failed. ${tokenRes.error.detail}`);


### PR DESCRIPTION
Closes #7 

updates auth middleware to post url encoded to match rfc and for compatibility with postman.

https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3