### PR TITLE
rollback manually updated version in lieu of release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dist
 .vscode
 .DS_Store
 src/neris-api.d.ts
+
+# npmrc
+.npmrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ulfsri/neris-nodejs-client",
-  "version": "1.0.6",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ulfsri/neris-nodejs-client",
-      "version": "1.0.6",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "openapi-fetch": "^0.13.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ulfsri/neris-nodejs-client",
-  "version": "1.0.6",
+  "version": "1.0.5",
   "description": "API client, authentication middleware, and binding for the Neris OpenAPI service",
   "files": [
     "dist"


### PR DESCRIPTION
The way the repo is setup, we are using standard-version on the command line to manage package versions, so to do a release we need to rollback the manually updated package.json version.  