### PR TITLE
chore(release): 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.6](https://github.com/ulfsri/neris-nodejs-client/compare/v1.0.5...v1.0.6) (2025-03-12)
+
 ### [1.0.5](https://github.com/ulfsri/neris-nodejs-client/compare/v1.0.4...v1.0.5) (2025-02-19)
 
 ### [1.0.4](https://github.com/ulfsri/neris-nodejs-client/compare/v1.0.0...v1.0.4) (2025-02-19)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ulfsri/neris-nodejs-client",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ulfsri/neris-nodejs-client",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "openapi-fetch": "^0.13.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ulfsri/neris-nodejs-client",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "API client, authentication middleware, and binding for the Neris OpenAPI service",
   "files": [
     "dist"


### PR DESCRIPTION
- Set the latest updates as the current release.