### PR TITLE
add a configurable user-agent to the client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -13,6 +13,7 @@ export const defaultConfig = (): NerisApiConfig => {
           username: process.env.NERIS_USERNAME || '',
           password: process.env.NERIS_PASSWORD || '',
         },
+        headers: process.env.NERIS_USER_AGENT || 'NERIS NodeJS Client',
       };
     case 'client_credentials':
       return {
@@ -22,6 +23,7 @@ export const defaultConfig = (): NerisApiConfig => {
           client_id: process.env.NERIS_CLIENT_ID || '',
           client_secret: process.env.NERIS_CLIENT_SECRET || '',
         },
+        headers: process.env.NERIS_USER_AGENT || 'NERIS NodeJS Client',
       };
     default:
       throw new Error("Bad grant_type. Options are 'client_credentials', or 'password'.");
@@ -36,6 +38,7 @@ export const createNerisClient = (config: NerisApiConfig = defaultConfig()): Ner
   const client = createClient<paths>({
     baseUrl: config.baseUrl,
     fetch: config.fetch,
+    headers: config.headers
   });
   const auth = authMiddleware(config);
   client.use(auth);

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,4 +18,5 @@ export interface NerisApiConfig {
   baseUrl: string;
   fetch?: (input: Request) => Promise<Response>;
   auth: NerisAuthentication;
+  headers: string;
 }


### PR DESCRIPTION
The concept of this commit is to setup a user agent for the client that is also configurable with a process.env so that we can either see when the client itself is being used without modification, or give users of the client a chance to identify themselves to the API when making requests.   EG:  <some RMS> client  