### PR TITLE
chore(release): 1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.10](https://github.com/ulfsri/neris-nodejs-client/compare/v1.0.9...v1.0.10) (2025-05-15)
+
 ### [1.0.9](https://github.com/ulfsri/neris-nodejs-client/compare/v1.0.7...v1.0.9) (2025-05-06)
 
 ### [1.0.8](https://github.com/ulfsri/neris-nodejs-client/compare/v1.0.7...v1.0.8) (2025-05-06)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ulfsri/neris-nodejs-client",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ulfsri/neris-nodejs-client",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "dependencies": {
         "openapi-fetch": "^0.13.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ulfsri/neris-nodejs-client",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "API client, authentication middleware, and binding for the Neris OpenAPI service",
   "files": [
     "dist"


### PR DESCRIPTION
For these API changes, mainly to update types

https://github.com/ulfsri/neris/pull/1314

